### PR TITLE
Support client-managed credentials for S3 buckets

### DIFF
--- a/figpack-api-cf/migrations/0007_nullable_bucket_credentials.sql
+++ b/figpack-api-cf/migrations/0007_nullable_bucket_credentials.sql
@@ -1,0 +1,46 @@
+-- Make AWS credentials nullable so buckets can use client-side credential
+-- resolution (e.g. boto3 with SSO/STS) instead of storing secrets in the DB.
+
+-- SQLite doesn't support ALTER COLUMN, so we recreate the table.
+-- The only change is that aws_access_key_id, aws_secret_access_key, and
+-- s3_endpoint are now nullable (drop NOT NULL).
+
+CREATE TABLE buckets_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  provider TEXT CHECK(provider IN ('cloudflare','aws')) NOT NULL,
+  description TEXT NOT NULL,
+  bucket_base_url TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  -- Flattened credentials (nullable for client-managed credential buckets)
+  aws_access_key_id TEXT,
+  aws_secret_access_key TEXT,
+  aws_session_token TEXT,
+  s3_endpoint TEXT,
+  -- Authorization
+  is_public INTEGER NOT NULL DEFAULT 0,
+  authorized_users TEXT DEFAULT '[]',
+  -- Native bucket name
+  native_bucket_name TEXT,
+  -- Region
+  region TEXT,
+  -- Owner
+  owner_email TEXT
+);
+
+INSERT INTO buckets_new
+  SELECT id, name, provider, description, bucket_base_url,
+         created_at, updated_at,
+         aws_access_key_id, aws_secret_access_key, aws_session_token, s3_endpoint,
+         is_public, authorized_users,
+         native_bucket_name, region, owner_email
+  FROM buckets;
+
+DROP TABLE buckets;
+ALTER TABLE buckets_new RENAME TO buckets;
+
+CREATE INDEX idx_buckets_name ON buckets(name);
+CREATE INDEX idx_buckets_provider ON buckets(provider);
+CREATE INDEX idx_buckets_created_at ON buckets(created_at);
+CREATE INDEX idx_buckets_owner_email ON buckets(owner_email);

--- a/figpack-api-cf/migrations/0008_add_figpack_json_column.sql
+++ b/figpack-api-cf/migrations/0008_add_figpack_json_column.sql
@@ -1,3 +1,0 @@
--- Store figpack.json content in the figures table for client-managed
--- credential buckets (where the Worker cannot write to S3 directly).
-ALTER TABLE figures ADD COLUMN figpack_json TEXT;

--- a/figpack-api-cf/migrations/0008_add_figpack_json_column.sql
+++ b/figpack-api-cf/migrations/0008_add_figpack_json_column.sql
@@ -1,0 +1,3 @@
+-- Store figpack.json content in the figures table for client-managed
+-- credential buckets (where the Worker cannot write to S3 directly).
+ALTER TABLE figures ADD COLUMN figpack_json TEXT;

--- a/figpack-api-cf/src/figureJsonManager.ts
+++ b/figpack-api-cf/src/figureJsonManager.ts
@@ -91,35 +91,48 @@ export async function updateFigureJson(figureUrl: string, env: Env, additionalFi
 	const bucketBaseUrl = bucketRow.bucket_base_url as string;
 	const provider = bucketRow.provider as string;
 
-	const region = bucketRow.region || (provider === 'cloudflare' ? 'auto' : 'us-east-1');
+	const hasServerCredentials = !!(bucketRow.aws_access_key_id && bucketRow.aws_secret_access_key);
 
-	const bucketInfo: BucketInfo = {
-		provider,
-		bucketName,
-		nativeBucketName: bucketRow.native_bucket_name || bucketName,
-		accessKeyId: bucketRow.aws_access_key_id,
-		secretAccessKey: bucketRow.aws_secret_access_key,
-		sessionToken: bucketRow.aws_session_token || undefined,
-		endpoint: bucketRow.s3_endpoint,
-		region,
-	};
+	// Always store figpack_json in the DB so the client can fetch it later
+	// (needed for client-managed credential buckets, harmless for server-managed ones)
+	await env.figpack_db
+		.prepare('UPDATE figures SET figpack_json = ?, updated_at = ? WHERE figure_url = ?;')
+		.bind(JSON.stringify(jsonContent, null, 2), Date.now(), figureUrl)
+		.run();
 
-	try {
-		const prefix = `${bucketBaseUrl}/`;
-		if (!figure.figureUrl.startsWith(prefix)) {
-			throw new Error(`Figure URL must start with ${prefix}`);
+	if (hasServerCredentials) {
+		const region = bucketRow.region || (provider === 'cloudflare' ? 'auto' : 'us-east-1');
+
+		const bucketInfo: BucketInfo = {
+			provider,
+			bucketName,
+			nativeBucketName: bucketRow.native_bucket_name || bucketName,
+			accessKeyId: bucketRow.aws_access_key_id,
+			secretAccessKey: bucketRow.aws_secret_access_key,
+			sessionToken: bucketRow.aws_session_token || undefined,
+			endpoint: bucketRow.s3_endpoint,
+			region,
+		};
+
+		try {
+			const prefix = `${bucketBaseUrl}/`;
+			if (!figure.figureUrl.startsWith(prefix)) {
+				throw new Error(`Figure URL must start with ${prefix}`);
+			}
+
+			const figureUrlWithoutIndexHtml = figure.figureUrl.endsWith('/index.html')
+				? figure.figureUrl.slice(0, -'/index.html'.length)
+				: figure.figureUrl;
+
+			const key = figureUrlWithoutIndexHtml.slice(prefix.length) + '/figpack.json';
+
+			// Store the JSON file in the figure's directory
+			await putObject(bucketInfo, key, JSON.stringify(jsonContent, null, 2), 'application/json');
+		} catch (error) {
+			console.error('Error updating figpack.json:', error);
+			throw error;
 		}
-
-		const figureUrlWithoutIndexHtml = figure.figureUrl.endsWith('/index.html')
-			? figure.figureUrl.slice(0, -'/index.html'.length)
-			: figure.figureUrl;
-
-		const key = figureUrlWithoutIndexHtml.slice(prefix.length) + '/figpack.json';
-
-		// Store the JSON file in the figure's directory
-		await putObject(bucketInfo, key, JSON.stringify(jsonContent, null, 2), 'application/json');
-	} catch (error) {
-		console.error('Error updating figpack.json:', error);
-		throw error;
 	}
+	// For client-managed credential buckets, the JSON is only stored in D1.
+	// The Python client will fetch it via the API and upload to S3 itself.
 }

--- a/figpack-api-cf/src/figureJsonManager.ts
+++ b/figpack-api-cf/src/figureJsonManager.ts
@@ -33,7 +33,7 @@ function rowToFigure(row: any): Figure {
 	};
 }
 
-export async function updateFigureJson(figureUrl: string, env: Env, additionalFields?: { [key: string]: any }): Promise<void> {
+export async function updateFigureJson(figureUrl: string, env: Env, additionalFields?: { [key: string]: any }): Promise<any> {
 	// Get the figure from the database
 	const figureRow = await env.figpack_db.prepare('SELECT * FROM figures WHERE figure_url = ?;').bind(figureUrl).first();
 
@@ -93,13 +93,6 @@ export async function updateFigureJson(figureUrl: string, env: Env, additionalFi
 
 	const hasServerCredentials = !!(bucketRow.aws_access_key_id && bucketRow.aws_secret_access_key);
 
-	// Always store figpack_json in the DB so the client can fetch it later
-	// (needed for client-managed credential buckets, harmless for server-managed ones)
-	await env.figpack_db
-		.prepare('UPDATE figures SET figpack_json = ?, updated_at = ? WHERE figure_url = ?;')
-		.bind(JSON.stringify(jsonContent, null, 2), Date.now(), figureUrl)
-		.run();
-
 	if (hasServerCredentials) {
 		const region = bucketRow.region || (provider === 'cloudflare' ? 'auto' : 'us-east-1');
 
@@ -133,6 +126,7 @@ export async function updateFigureJson(figureUrl: string, env: Env, additionalFi
 			throw error;
 		}
 	}
-	// For client-managed credential buckets, the JSON is only stored in D1.
-	// The Python client will fetch it via the API and upload to S3 itself.
+	// For client-managed credential buckets, the JSON is returned to the caller
+	// so the Python client can upload it to S3 itself.
+	return jsonContent;
 }

--- a/figpack-api-cf/src/handlers/bucketsHandler.ts
+++ b/figpack-api-cf/src/handlers/bucketsHandler.ts
@@ -224,20 +224,25 @@ export async function handleCreateBucket(request: Request, env: Env, rateLimitRe
 			);
 		}
 
-		// Extract credentials from either format
-		const accessKeyId = awsAccessKeyId || credentials?.AWS_ACCESS_KEY_ID;
-		const secretAccessKey = awsSecretAccessKey || credentials?.AWS_SECRET_ACCESS_KEY;
+		// Extract credentials from either format.
+		// Credentials are optional: when omitted, the client is responsible for
+		// resolving them (e.g. via boto3 SSO/STS) and uploading directly to S3.
+		const accessKeyId = awsAccessKeyId || credentials?.AWS_ACCESS_KEY_ID || null;
+		const secretAccessKey = awsSecretAccessKey || credentials?.AWS_SECRET_ACCESS_KEY || null;
 		const sessionToken: string | undefined =
 			(typeof awsSessionToken === 'string' && awsSessionToken
 				? awsSessionToken
 				: undefined) || credentials?.AWS_SESSION_TOKEN;
-		const endpoint = s3Endpoint || credentials?.S3_ENDPOINT;
+		const endpoint = s3Endpoint || credentials?.S3_ENDPOINT || null;
 
-		if (!accessKeyId || !secretAccessKey || !endpoint) {
+		// If any credential is provided, all must be provided
+		const hasAnyCredential = accessKeyId || secretAccessKey || endpoint;
+		const hasAllCredentials = accessKeyId && secretAccessKey && endpoint;
+		if (hasAnyCredential && !hasAllCredentials) {
 			return json(
 				{
 					success: false,
-					message: 'All credential fields (awsAccessKeyId, awsSecretAccessKey, s3Endpoint) are required',
+					message: 'Either provide all credential fields (awsAccessKeyId, awsSecretAccessKey, s3Endpoint) or none (for client-managed credentials)',
 				},
 				400,
 			);

--- a/figpack-api-cf/src/handlers/figuresHandler.ts
+++ b/figpack-api-cf/src/handlers/figuresHandler.ts
@@ -712,7 +712,7 @@ export async function handleFinalizeFigure(request: Request, env: Env, rateLimit
 			.run();
 
 		// Fetch updated figure
-		const updatedRow = await env.figpack_db.prepare('SELECT * FROM figures WHERE figure_url = ?').bind(figureUrl).first();
+		// (updatedRow is not used directly — finalRow is fetched after updateFigureJson to include figpack_json)
 
 		// Update figpack.json in S3
 		try {
@@ -722,12 +722,36 @@ export async function handleFinalizeFigure(request: Request, env: Env, rateLimit
 			// Don't fail the request if figpack.json update fails
 		}
 
+		// Check if this bucket uses client-managed credentials
+		const bucketName = (figureRow.bucket as string) || 'figpack-figures';
+		const bucketRow = await env.figpack_db.prepare('SELECT * FROM buckets WHERE name = ?;').bind(bucketName).first();
+		const hasServerCredentials = !!(bucketRow && bucketRow.aws_access_key_id && bucketRow.aws_secret_access_key);
+
+		// Re-fetch figure to get the figpack_json that was just saved
+		const finalRow = await env.figpack_db.prepare('SELECT * FROM figures WHERE figure_url = ?').bind(figureUrl).first();
+
+		const responseBody: any = {
+			success: true,
+			message: 'Figure finalized successfully',
+			figure: parseFigure(finalRow),
+		};
+
+		// For client-managed credential buckets, include the figpack.json content
+		// and bucket info so the Python client can upload it to S3
+		if (!hasServerCredentials && finalRow) {
+			responseBody.figpackJson = finalRow.figpack_json ? JSON.parse(finalRow.figpack_json as string) : null;
+			if (bucketRow) {
+				responseBody.bucket = {
+					nativeBucketName: (bucketRow.native_bucket_name as string) || bucketName,
+					region: (bucketRow.region as string) || 'us-east-1',
+					provider: bucketRow.provider as string,
+					bucketBaseUrl: bucketRow.bucket_base_url as string,
+				};
+			}
+		}
+
 		return json(
-			{
-				success: true,
-				message: 'Figure finalized successfully',
-				figure: parseFigure(updatedRow),
-			},
+			responseBody,
 			200,
 			{
 				'X-RateLimit-Limit': '30',

--- a/figpack-api-cf/src/handlers/figuresHandler.ts
+++ b/figpack-api-cf/src/handlers/figuresHandler.ts
@@ -727,12 +727,10 @@ export async function handleFinalizeFigure(request: Request, env: Env, rateLimit
 			.bind('completed', now, now, now, figureUrl)
 			.run();
 
-		// Fetch updated figure
-		// (updatedRow is not used directly — finalRow is fetched after updateFigureJson to include figpack_json)
-
 		// Update figpack.json in S3
+		let figpackJsonContent: any = null;
 		try {
-			await updateFigureJson(figureUrl, env);
+			figpackJsonContent = await updateFigureJson(figureUrl, env);
 		} catch (error) {
 			console.error('Error updating figpack.json:', error);
 			// Don't fail the request if figpack.json update fails
@@ -743,7 +741,7 @@ export async function handleFinalizeFigure(request: Request, env: Env, rateLimit
 		const bucketRow = await env.figpack_db.prepare('SELECT * FROM buckets WHERE name = ?;').bind(bucketName).first();
 		const hasServerCredentials = !!(bucketRow && bucketRow.aws_access_key_id && bucketRow.aws_secret_access_key);
 
-		// Re-fetch figure to get the figpack_json that was just saved
+		// Re-fetch figure to get the updated status
 		const finalRow = await env.figpack_db.prepare('SELECT * FROM figures WHERE figure_url = ?').bind(figureUrl).first();
 
 		const responseBody: any = {
@@ -754,8 +752,8 @@ export async function handleFinalizeFigure(request: Request, env: Env, rateLimit
 
 		// For client-managed credential buckets, include the figpack.json content
 		// and bucket info so the Python client can upload it to S3
-		if (!hasServerCredentials && finalRow) {
-			responseBody.figpackJson = finalRow.figpack_json ? JSON.parse(finalRow.figpack_json as string) : null;
+		if (!hasServerCredentials && figpackJsonContent) {
+			responseBody.figpackJson = figpackJsonContent;
 			if (bucketRow) {
 				responseBody.bucket = {
 					nativeBucketName: (bucketRow.native_bucket_name as string) || bucketName,

--- a/figpack-api-cf/src/handlers/uploadHandler.ts
+++ b/figpack-api-cf/src/handlers/uploadHandler.ts
@@ -1,7 +1,7 @@
 import { authenticateUser } from '../auth';
 import { API_LIMITS } from '../config';
 import { BucketInfo, getSignedUploadUrl } from '../s3Utils';
-import { BatchUploadRequest, Env, RateLimitResult, SignedUrlInfo } from '../types';
+import { BatchUploadRequest, ClientSignedFileInfo, Env, RateLimitResult, SignedUrlInfo } from '../types';
 import { json } from '../utils';
 
 // File path validation functions
@@ -266,8 +266,12 @@ export async function handleUpload(request: Request, env: Env, rateLimitResult: 
 			region: bucketRow.region || (provider === 'cloudflare' ? 'auto' : 'us-east-1'),
 		};
 
-		// Validate all files and generate signed URLs
+		// Determine whether the server can sign URLs or the client must handle it
+		const hasServerCredentials = !!(bucketInfo.accessKeyId && bucketInfo.secretAccessKey);
+
+		// Validate all files and compute keys
 		const signedUrls: SignedUrlInfo[] = [];
+		const clientSignedFiles: ClientSignedFileInfo[] = [];
 
 		for (const file of files) {
 			const { relativePath, size } = file;
@@ -326,23 +330,31 @@ export async function handleUpload(request: Request, env: Env, rateLimitResult: 
 			// Extract the file key from the destination URL
 			const fileKey = destinationUrl.slice(`${bucketBaseUrl}/`.length);
 
-			// Generate signed URL
-			try {
-				const signedUrl = await getSignedUploadUrl(bucketInfo, fileKey);
+			if (hasServerCredentials) {
+				// Server-signed mode: generate presigned URL
+				try {
+					const signedUrl = await getSignedUploadUrl(bucketInfo, fileKey);
 
-				signedUrls.push({
+					signedUrls.push({
+						relativePath,
+						signedUrl,
+					});
+				} catch (err) {
+					console.error(`Error generating signed URL for ${relativePath}:`, err);
+					return json(
+						{
+							success: false,
+							message: `Error generating signed URL for ${relativePath}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+						},
+						500,
+					);
+				}
+			} else {
+				// Client-signed mode: return the key for the client to sign/upload
+				clientSignedFiles.push({
 					relativePath,
-					signedUrl,
+					key: fileKey,
 				});
-			} catch (err) {
-				console.error(`Error generating signed URL for ${relativePath}:`, err);
-				return json(
-					{
-						success: false,
-						message: `Error generating signed URL for ${relativePath}: ${err instanceof Error ? err.message : 'Unknown error'}`,
-					},
-					500,
-				);
 			}
 		}
 
@@ -353,19 +365,42 @@ export async function handleUpload(request: Request, env: Env, rateLimitResult: 
 			.bind(now, now, figureUrl)
 			.run();
 
-		return json(
-			{
-				success: true,
-				message: `Generated ${signedUrls.length} signed URLs successfully`,
-				signedUrls,
-			},
-			200,
-			{
-				'X-RateLimit-Limit': '30',
-				'X-RateLimit-Remaining': rateLimitResult.remaining.toString(),
-				'X-RateLimit-Reset': Math.ceil(rateLimitResult.resetTime / 1000).toString(),
-			},
-		);
+		const rateLimitHeaders = {
+			'X-RateLimit-Limit': '30',
+			'X-RateLimit-Remaining': rateLimitResult.remaining.toString(),
+			'X-RateLimit-Reset': Math.ceil(rateLimitResult.resetTime / 1000).toString(),
+		};
+
+		if (hasServerCredentials) {
+			return json(
+				{
+					success: true,
+					mode: 'server-signed',
+					message: `Generated ${signedUrls.length} signed URLs successfully`,
+					signedUrls,
+				},
+				200,
+				rateLimitHeaders,
+			);
+		} else {
+			const nativeBucketName = (bucketRow.native_bucket_name as string) || bucketName;
+			const region = (bucketRow.region as string) || (provider === 'cloudflare' ? 'auto' : 'us-east-1');
+			return json(
+				{
+					success: true,
+					mode: 'client-signed',
+					message: `Prepared ${clientSignedFiles.length} file keys for client-side upload`,
+					bucket: {
+						nativeBucketName,
+						region,
+						provider,
+					},
+					files: clientSignedFiles,
+				},
+				200,
+				rateLimitHeaders,
+			);
+		}
 	} catch (error) {
 		console.error('Upload API error:', error);
 

--- a/figpack-api-cf/src/types.ts
+++ b/figpack-api-cf/src/types.ts
@@ -48,13 +48,15 @@ export interface Bucket {
 	bucketBaseUrl: string;
 	createdAt: number;
 	updatedAt: number;
-	// Credentials (flattened from nested object)
-	awsAccessKeyId: string;
-	awsSecretAccessKey: string;
+	// Credentials (flattened from nested object).
+	// Nullable: when empty, the client is responsible for resolving credentials
+	// (e.g. via boto3 SSO/STS) and uploading directly to S3.
+	awsAccessKeyId?: string;
+	awsSecretAccessKey?: string;
 	// Optional STS session token. When set, forwarded to the S3 SDK so
 	// presigned URLs include X-Amz-Security-Token.
 	awsSessionToken?: string;
-	s3Endpoint: string;
+	s3Endpoint?: string;
 	// AWS region (e.g. us-west-2). For Cloudflare R2 use 'auto'.
 	region?: string;
 	// Authorization (flattened from nested object)
@@ -132,10 +134,24 @@ export interface SignedUrlInfo {
 	signedUrl: string;
 }
 
+export interface ClientSignedFileInfo {
+	relativePath: string;
+	key: string; // The S3 object key the client should upload to
+}
+
 export interface BatchUploadResponse {
 	success: boolean;
 	message: string;
+	// Server-signed mode: Worker generated presigned URLs
+	mode?: 'server-signed' | 'client-signed';
 	signedUrls?: SignedUrlInfo[];
+	// Client-signed mode: bucket info + keys for client to sign/upload
+	bucket?: {
+		nativeBucketName: string;
+		region: string;
+		provider: string;
+	};
+	files?: ClientSignedFileInfo[];
 }
 
 // Usage stats interfaces

--- a/figpack-manage/src/pages/BucketsPage/AddBucketDialog.tsx
+++ b/figpack-manage/src/pages/BucketsPage/AddBucketDialog.tsx
@@ -16,6 +16,8 @@ import {
   FormControlLabel,
   Switch,
   Chip,
+  RadioGroup,
+  Radio,
 } from "@mui/material";
 import React, { useState } from "react";
 import type { Bucket } from "./bucketsApi";
@@ -40,6 +42,8 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
     provider: "cloudflare" as "cloudflare" | "aws",
     description: "",
     bucketBaseUrl: "",
+    // Credential mode
+    credentialMode: "long-term" as "long-term" | "user-credentials",
     // Flattened credentials
     awsAccessKeyId: "",
     awsSecretAccessKey: "",
@@ -64,6 +68,7 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
         provider: "cloudflare",
         description: "",
         bucketBaseUrl: "",
+        credentialMode: "long-term",
         awsAccessKeyId: "",
         awsSecretAccessKey: "",
         awsSessionToken: "",
@@ -106,17 +111,17 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
       }
     }
 
-    if (!formData.awsAccessKeyId.trim()) {
+    if (!formData.awsAccessKeyId.trim() && formData.credentialMode === "long-term") {
       errors.awsAccessKeyId = "Access Key ID is required";
     }
 
-    if (!formData.awsSecretAccessKey.trim()) {
+    if (!formData.awsSecretAccessKey.trim() && formData.credentialMode === "long-term") {
       errors.awsSecretAccessKey = "Secret Access Key is required";
     }
 
-    if (!formData.s3Endpoint.trim()) {
+    if (!formData.s3Endpoint.trim() && formData.credentialMode === "long-term") {
       errors.s3Endpoint = "S3 Endpoint is required";
-    } else {
+    } else if (formData.s3Endpoint.trim()) {
       try {
         new URL(formData.s3Endpoint);
       } catch {
@@ -230,57 +235,89 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
             Credentials
           </Typography>
 
-          <TextField
-            fullWidth
-            label="Access Key ID"
-            value={formData.awsAccessKeyId}
-            onChange={(e) =>
-              handleInputChange("awsAccessKeyId", e.target.value)
-            }
-            error={!!formErrors.awsAccessKeyId}
-            helperText={formErrors.awsAccessKeyId}
-            margin="normal"
-            disabled={loading}
-          />
+          <FormControl component="fieldset" sx={{ mb: 2 }}>
+            <RadioGroup
+              row
+              value={formData.credentialMode}
+              onChange={(e) =>
+                handleInputChange("credentialMode", e.target.value)
+              }
+            >
+              <FormControlLabel
+                value="long-term"
+                control={<Radio />}
+                label="Long-term Credentials"
+                disabled={loading}
+              />
+              <FormControlLabel
+                value="user-credentials"
+                control={<Radio />}
+                label="User Credentials"
+                disabled={loading}
+              />
+            </RadioGroup>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: -0.5 }}>
+              {formData.credentialMode === "long-term"
+                ? "Store access keys in the server. The server generates presigned upload URLs."
+                : "No secrets stored. The uploading client (e.g. Python/boto3) resolves credentials on the fly via AWS SSO, environment variables, or instance profile."}
+            </Typography>
+          </FormControl>
 
-          <TextField
-            fullWidth
-            label="Secret Access Key"
-            type="password"
-            value={formData.awsSecretAccessKey}
-            onChange={(e) =>
-              handleInputChange("awsSecretAccessKey", e.target.value)
-            }
-            error={!!formErrors.awsSecretAccessKey}
-            helperText={formErrors.awsSecretAccessKey}
-            margin="normal"
-            disabled={loading}
-          />
+          {formData.credentialMode === "long-term" && (
+            <>
+              <TextField
+                fullWidth
+                label="Access Key ID"
+                value={formData.awsAccessKeyId}
+                onChange={(e) =>
+                  handleInputChange("awsAccessKeyId", e.target.value)
+                }
+                error={!!formErrors.awsAccessKeyId}
+                helperText={formErrors.awsAccessKeyId}
+                margin="normal"
+                disabled={loading}
+              />
 
-          <TextField
-            fullWidth
-            label="Session Token (optional)"
-            type="password"
-            value={formData.awsSessionToken}
-            onChange={(e) =>
-              handleInputChange("awsSessionToken", e.target.value)
-            }
-            helperText="For STS / temporary credentials. Leave blank for long-lived IAM keys."
-            margin="normal"
-            disabled={loading}
-          />
+              <TextField
+                fullWidth
+                label="Secret Access Key"
+                type="password"
+                value={formData.awsSecretAccessKey}
+                onChange={(e) =>
+                  handleInputChange("awsSecretAccessKey", e.target.value)
+                }
+                error={!!formErrors.awsSecretAccessKey}
+                helperText={formErrors.awsSecretAccessKey}
+                margin="normal"
+                disabled={loading}
+              />
 
-          <TextField
-            fullWidth
-            label="S3 Endpoint"
-            value={formData.s3Endpoint}
-            onChange={(e) => handleInputChange("s3Endpoint", e.target.value)}
-            error={!!formErrors.s3Endpoint}
-            helperText={formErrors.s3Endpoint}
-            placeholder={getEndpointPlaceholder()}
-            margin="normal"
-            disabled={loading}
-          />
+              <TextField
+                fullWidth
+                label="Session Token (optional)"
+                type="password"
+                value={formData.awsSessionToken}
+                onChange={(e) =>
+                  handleInputChange("awsSessionToken", e.target.value)
+                }
+                helperText="For STS / temporary credentials. Leave blank for long-lived IAM keys."
+                margin="normal"
+                disabled={loading}
+              />
+
+              <TextField
+                fullWidth
+                label="S3 Endpoint"
+                value={formData.s3Endpoint}
+                onChange={(e) => handleInputChange("s3Endpoint", e.target.value)}
+                error={!!formErrors.s3Endpoint}
+                helperText={formErrors.s3Endpoint}
+                placeholder={getEndpointPlaceholder()}
+                margin="normal"
+                disabled={loading}
+              />
+            </>
+          )}
 
           <TextField
             fullWidth

--- a/figpack-manage/src/pages/BucketsPage/AddBucketDialog.tsx
+++ b/figpack-manage/src/pages/BucketsPage/AddBucketDialog.tsx
@@ -48,7 +48,7 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
     description: "",
     bucketBaseUrl: "",
     // Credential mode
-    credentialMode: "long-term" as "long-term" | "user-credentials",
+    credentialMode: "server" as "server" | "client",
     // Flattened credentials
     awsAccessKeyId: "",
     awsSecretAccessKey: "",
@@ -75,7 +75,7 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
         provider: "cloudflare",
         description: "",
         bucketBaseUrl: "",
-        credentialMode: "long-term",
+        credentialMode: "server",
         awsAccessKeyId: "",
         awsSecretAccessKey: "",
         awsSessionToken: "",
@@ -119,15 +119,15 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
       }
     }
 
-    if (!formData.awsAccessKeyId.trim() && formData.credentialMode === "long-term") {
+    if (!formData.awsAccessKeyId.trim() && formData.credentialMode === "server") {
       errors.awsAccessKeyId = "Access Key ID is required";
     }
 
-    if (!formData.awsSecretAccessKey.trim() && formData.credentialMode === "long-term") {
+    if (!formData.awsSecretAccessKey.trim() && formData.credentialMode === "server") {
       errors.awsSecretAccessKey = "Secret Access Key is required";
     }
 
-    if (!formData.s3Endpoint.trim() && formData.credentialMode === "long-term") {
+    if (!formData.s3Endpoint.trim() && formData.credentialMode === "server") {
       errors.s3Endpoint = "S3 Endpoint is required";
     } else if (formData.s3Endpoint.trim()) {
       try {
@@ -257,26 +257,26 @@ const AddBucketDialog: React.FC<AddBucketDialogProps> = ({
               }
             >
               <FormControlLabel
-                value="long-term"
+                value="server"
                 control={<Radio />}
-                label="Long-term Credentials"
+                label="Server"
                 disabled={loading}
               />
               <FormControlLabel
-                value="user-credentials"
+                value="client"
                 control={<Radio />}
-                label="User Credentials"
+                label="Client"
                 disabled={loading}
               />
             </RadioGroup>
             <Typography variant="body2" color="text.secondary" sx={{ mt: -0.5 }}>
-              {formData.credentialMode === "long-term"
+              {formData.credentialMode === "server"
                 ? "Store access keys in the server. The server generates presigned upload URLs."
                 : "No secrets stored. The uploading client (e.g. Python/boto3) resolves credentials on the fly via AWS SSO, environment variables, or instance profile."}
             </Typography>
           </FormControl>
 
-          {formData.credentialMode === "long-term" && (
+          {formData.credentialMode === "server" && (
             <>
               <TextField
                 fullWidth

--- a/figpack-manage/src/pages/BucketsPage/EditBucketDialog.tsx
+++ b/figpack-manage/src/pages/BucketsPage/EditBucketDialog.tsx
@@ -16,6 +16,8 @@ import {
   FormControlLabel,
   Switch,
   Chip,
+  RadioGroup,
+  Radio,
 } from "@mui/material";
 import React, { useState, useEffect } from "react";
 import type { Bucket } from "./bucketsApi";
@@ -44,6 +46,8 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
     provider: "cloudflare" as "cloudflare" | "aws",
     description: "",
     bucketBaseUrl: "",
+    // Credential mode
+    credentialMode: "long-term" as "long-term" | "user-credentials",
     // Flattened credentials
     awsAccessKeyId: "",
     awsSecretAccessKey: "",
@@ -68,15 +72,18 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
   // Update form data when bucket changes
   useEffect(() => {
     if (bucket) {
+      // Determine credential mode from whether the bucket has stored credentials
+      const hasCredentials = !!bucket.awsAccessKeyId;
       setFormData({
         provider: bucket.provider,
         description: bucket.description,
         bucketBaseUrl: bucket.bucketBaseUrl,
+        credentialMode: hasCredentials ? "long-term" : "user-credentials",
         // Flattened credentials
-        awsAccessKeyId: bucket.awsAccessKeyId,
+        awsAccessKeyId: bucket.awsAccessKeyId || "",
         awsSecretAccessKey: "", // Don't pre-fill the secret key for security
         awsSessionToken: "", // Likewise; server returns placeholder if set.
-        s3Endpoint: bucket.s3Endpoint,
+        s3Endpoint: bucket.s3Endpoint || "",
         region: bucket.region || "",
         // Flattened authorization
         isPublic: bucket.isPublic,
@@ -115,13 +122,13 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
       }
     }
 
-    if (!formData.awsAccessKeyId.trim()) {
+    if (!formData.awsAccessKeyId.trim() && formData.credentialMode === "long-term") {
       errors.awsAccessKeyId = "Access Key ID is required";
     }
 
-    if (!formData.s3Endpoint.trim()) {
+    if (!formData.s3Endpoint.trim() && formData.credentialMode === "long-term") {
       errors.s3Endpoint = "S3 Endpoint is required";
-    } else {
+    } else if (formData.s3Endpoint.trim()) {
       try {
         new URL(formData.s3Endpoint);
       } catch {
@@ -145,23 +152,32 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
         bucketBaseUrl: formData.bucketBaseUrl,
         isPublic: formData.isPublic,
         authorizedUsers: formData.authorizedUsers,
-        awsAccessKeyId: formData.awsAccessKeyId,
-        s3Endpoint: formData.s3Endpoint,
         region: formData.region || undefined,
         nativeBucketName: formData.nativeBucketName || undefined,
       };
 
-      // Only update secret key if provided (for security)
-      if (formData.awsSecretAccessKey.trim()) {
-        updateData.awsSecretAccessKey = formData.awsSecretAccessKey;
-      }
+      if (formData.credentialMode === "long-term") {
+        updateData.awsAccessKeyId = formData.awsAccessKeyId;
+        updateData.s3Endpoint = formData.s3Endpoint;
 
-      // Session token: empty string clears it on the backend; a non-empty
-      // value sets it; omitting the field leaves it unchanged.
-      if (clearSessionToken) {
+        // Only update secret key if provided (for security)
+        if (formData.awsSecretAccessKey.trim()) {
+          updateData.awsSecretAccessKey = formData.awsSecretAccessKey;
+        }
+
+        // Session token: empty string clears it on the backend; a non-empty
+        // value sets it; omitting the field leaves it unchanged.
+        if (clearSessionToken) {
+          updateData.awsSessionToken = "";
+        } else if (formData.awsSessionToken.trim()) {
+          updateData.awsSessionToken = formData.awsSessionToken;
+        }
+      } else {
+        // User-credentials mode: clear stored credentials
+        updateData.awsAccessKeyId = "";
+        updateData.awsSecretAccessKey = "";
         updateData.awsSessionToken = "";
-      } else if (formData.awsSessionToken.trim()) {
-        updateData.awsSessionToken = formData.awsSessionToken;
+        updateData.s3Endpoint = "";
       }
 
       onUpdateBucket(bucket.name, updateData);
@@ -263,81 +279,113 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
             Credentials
           </Typography>
 
-          <TextField
-            fullWidth
-            label="Access Key ID"
-            value={formData.awsAccessKeyId}
-            onChange={(e) =>
-              handleInputChange("awsAccessKeyId", e.target.value)
-            }
-            error={!!formErrors.awsAccessKeyId}
-            helperText={formErrors.awsAccessKeyId}
-            margin="normal"
-            disabled={loading}
-          />
-
-          <TextField
-            fullWidth
-            label="Secret Access Key"
-            type="password"
-            value={formData.awsSecretAccessKey}
-            onChange={(e) =>
-              handleInputChange("awsSecretAccessKey", e.target.value)
-            }
-            error={!!formErrors.awsSecretAccessKey}
-            helperText={
-              formErrors.awsSecretAccessKey ||
-              "Leave empty to keep existing secret key"
-            }
-            margin="normal"
-            disabled={loading}
-            placeholder="Leave empty to keep existing"
-          />
-
-          <TextField
-            fullWidth
-            label="Session Token (optional)"
-            type="password"
-            value={formData.awsSessionToken}
-            onChange={(e) =>
-              handleInputChange("awsSessionToken", e.target.value)
-            }
-            helperText={
-              hasSessionToken
-                ? "Leave empty to keep existing session token, or check Clear below."
-                : "For STS / temporary credentials. Leave blank for long-lived IAM keys."
-            }
-            margin="normal"
-            disabled={loading || clearSessionToken}
-            placeholder={
-              hasSessionToken ? "Leave empty to keep existing" : ""
-            }
-          />
-          {hasSessionToken && (
-            <FormControlLabel
-              sx={{ mt: -1, mb: 1 }}
-              control={
-                <Switch
-                  checked={clearSessionToken}
-                  onChange={(e) => setClearSessionToken(e.target.checked)}
-                  disabled={loading}
-                />
+          <FormControl component="fieldset" sx={{ mb: 2 }}>
+            <RadioGroup
+              row
+              value={formData.credentialMode}
+              onChange={(e) =>
+                handleInputChange("credentialMode", e.target.value)
               }
-              label="Clear session token"
-            />
-          )}
+            >
+              <FormControlLabel
+                value="long-term"
+                control={<Radio />}
+                label="Long-term Credentials"
+                disabled={loading}
+              />
+              <FormControlLabel
+                value="user-credentials"
+                control={<Radio />}
+                label="User Credentials"
+                disabled={loading}
+              />
+            </RadioGroup>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: -0.5 }}>
+              {formData.credentialMode === "long-term"
+                ? "Store access keys in the server. The server generates presigned upload URLs."
+                : "No secrets stored. The uploading client (e.g. Python/boto3) resolves credentials on the fly via AWS SSO, environment variables, or instance profile."}
+            </Typography>
+          </FormControl>
 
-          <TextField
-            fullWidth
-            label="S3 Endpoint"
-            value={formData.s3Endpoint}
-            onChange={(e) => handleInputChange("s3Endpoint", e.target.value)}
-            error={!!formErrors.s3Endpoint}
-            helperText={formErrors.s3Endpoint}
-            placeholder={getEndpointPlaceholder()}
-            margin="normal"
-            disabled={loading}
-          />
+          {formData.credentialMode === "long-term" && (
+            <>
+              <TextField
+                fullWidth
+                label="Access Key ID"
+                value={formData.awsAccessKeyId}
+                onChange={(e) =>
+                  handleInputChange("awsAccessKeyId", e.target.value)
+                }
+                error={!!formErrors.awsAccessKeyId}
+                helperText={formErrors.awsAccessKeyId}
+                margin="normal"
+                disabled={loading}
+              />
+
+              <TextField
+                fullWidth
+                label="Secret Access Key"
+                type="password"
+                value={formData.awsSecretAccessKey}
+                onChange={(e) =>
+                  handleInputChange("awsSecretAccessKey", e.target.value)
+                }
+                error={!!formErrors.awsSecretAccessKey}
+                helperText={
+                  formErrors.awsSecretAccessKey ||
+                  "Leave empty to keep existing secret key"
+                }
+                margin="normal"
+                disabled={loading}
+                placeholder="Leave empty to keep existing"
+              />
+
+              <TextField
+                fullWidth
+                label="Session Token (optional)"
+                type="password"
+                value={formData.awsSessionToken}
+                onChange={(e) =>
+                  handleInputChange("awsSessionToken", e.target.value)
+                }
+                helperText={
+                  hasSessionToken
+                    ? "Leave empty to keep existing session token, or check Clear below."
+                    : "For STS / temporary credentials. Leave blank for long-lived IAM keys."
+                }
+                margin="normal"
+                disabled={loading || clearSessionToken}
+                placeholder={
+                  hasSessionToken ? "Leave empty to keep existing" : ""
+                }
+              />
+              {hasSessionToken && (
+                <FormControlLabel
+                  sx={{ mt: -1, mb: 1 }}
+                  control={
+                    <Switch
+                      checked={clearSessionToken}
+                      onChange={(e) => setClearSessionToken(e.target.checked)}
+                      disabled={loading}
+                    />
+                  }
+                  label="Clear session token"
+                />
+              )}
+
+              <TextField
+                fullWidth
+                label="S3 Endpoint"
+                value={formData.s3Endpoint}
+                onChange={(e) => handleInputChange("s3Endpoint", e.target.value)}
+                error={!!formErrors.s3Endpoint}
+                helperText={formErrors.s3Endpoint}
+                placeholder={getEndpointPlaceholder()}
+                margin="normal"
+                disabled={loading}
+              />
+            </>
+          )}
 
           <TextField
             fullWidth

--- a/figpack-manage/src/pages/BucketsPage/EditBucketDialog.tsx
+++ b/figpack-manage/src/pages/BucketsPage/EditBucketDialog.tsx
@@ -53,7 +53,7 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
     description: "",
     bucketBaseUrl: "",
     // Credential mode
-    credentialMode: "long-term" as "long-term" | "user-credentials",
+    credentialMode: "server" as "server" | "client",
     // Flattened credentials
     awsAccessKeyId: "",
     awsSecretAccessKey: "",
@@ -86,7 +86,7 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
         provider: bucket.provider,
         description: bucket.description,
         bucketBaseUrl: bucket.bucketBaseUrl,
-        credentialMode: hasCredentials ? "long-term" : "user-credentials",
+        credentialMode: hasCredentials ? "server" : "client",
         // Flattened credentials
         awsAccessKeyId: bucket.awsAccessKeyId || "",
         awsSecretAccessKey: "", // Don't pre-fill the secret key for security
@@ -131,11 +131,11 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
       }
     }
 
-    if (!formData.awsAccessKeyId.trim() && formData.credentialMode === "long-term") {
+    if (!formData.awsAccessKeyId.trim() && formData.credentialMode === "server") {
       errors.awsAccessKeyId = "Access Key ID is required";
     }
 
-    if (!formData.s3Endpoint.trim() && formData.credentialMode === "long-term") {
+    if (!formData.s3Endpoint.trim() && formData.credentialMode === "server") {
       errors.s3Endpoint = "S3 Endpoint is required";
     } else if (formData.s3Endpoint.trim()) {
       try {
@@ -165,7 +165,7 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
         nativeBucketName: formData.nativeBucketName || undefined,
       };
 
-      if (formData.credentialMode === "long-term") {
+      if (formData.credentialMode === "server") {
         updateData.awsAccessKeyId = formData.awsAccessKeyId;
         updateData.s3Endpoint = formData.s3Endpoint;
 
@@ -182,7 +182,7 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
           updateData.awsSessionToken = formData.awsSessionToken;
         }
       } else {
-        // User-credentials mode: clear stored credentials
+        // Client mode: clear stored credentials
         updateData.awsAccessKeyId = "";
         updateData.awsSecretAccessKey = "";
         updateData.awsSessionToken = "";
@@ -302,26 +302,26 @@ const EditBucketDialog: React.FC<EditBucketDialogProps> = ({
               }
             >
               <FormControlLabel
-                value="long-term"
+                value="server"
                 control={<Radio />}
-                label="Long-term Credentials"
+                label="Server"
                 disabled={loading}
               />
               <FormControlLabel
-                value="user-credentials"
+                value="client"
                 control={<Radio />}
-                label="User Credentials"
+                label="Client"
                 disabled={loading}
               />
             </RadioGroup>
             <Typography variant="body2" color="text.secondary" sx={{ mt: -0.5 }}>
-              {formData.credentialMode === "long-term"
+              {formData.credentialMode === "server"
                 ? "Store access keys in the server. The server generates presigned upload URLs."
                 : "No secrets stored. The uploading client (e.g. Python/boto3) resolves credentials on the fly via AWS SSO, environment variables, or instance profile."}
             </Typography>
           </FormControl>
 
-          {formData.credentialMode === "long-term" && (
+          {formData.credentialMode === "server" && (
             <>
               <TextField
                 fullWidth

--- a/figpack-manage/src/pages/BucketsPage/bucketsApi.ts
+++ b/figpack-manage/src/pages/BucketsPage/bucketsApi.ts
@@ -8,15 +8,20 @@ export interface Bucket {
   bucketBaseUrl: string;
   createdAt: number;
   updatedAt: number;
-  // Flattened credentials. The API returns awsSecretAccessKey as the placeholder
+  // Credential mode: "long-term" stores secrets in the DB; "user-credentials"
+  // means the uploading client resolves credentials on the fly (e.g. boto3 SSO).
+  // Derived from whether awsAccessKeyId is set; not stored in DB itself.
+  credentialMode?: "long-term" | "user-credentials";
+  // Flattened credentials. Optional when credentialMode is "user-credentials".
+  // The API returns awsSecretAccessKey as the placeholder
   // string "***HIDDEN***"; sending it back unchanged means "do not modify".
-  awsAccessKeyId: string;
-  awsSecretAccessKey: string;
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
   // Optional STS session token. The API returns "***HIDDEN***" when one is set
   // and undefined when none is configured. To clear, send an empty string;
   // the placeholder echoed back means "leave unchanged".
   awsSessionToken?: string;
-  s3Endpoint: string;
+  s3Endpoint?: string;
   // AWS region (e.g. us-west-2). For Cloudflare R2 use 'auto' (or leave blank).
   region?: string;
   // Flattened authorization

--- a/figpack/core/_upload_bundle.py
+++ b/figpack/core/_upload_bundle.py
@@ -15,17 +15,14 @@ from .config import FIGPACK_API_BASE_URL, FIGPACK_BUCKET
 thisdir = pathlib.Path(__file__).parent.resolve()
 
 
-def _get_batch_signed_urls(figure_url: str, files_batch: list, api_key: str) -> dict:
+def _get_upload_info(figure_url: str, files_batch: list, api_key: str) -> dict:
     """
-    Get signed URLs for a batch of files
+    Get upload info for a batch of files from the API.
 
-    Args:
-        figure_url: The figure URL
-        files_batch: List of tuples (relative_path, file_path)
-        api_key: API key for authentication
-
-    Returns:
-        dict: Mapping of relative_path to signed_url
+    Returns a dict with:
+      - "mode": "server-signed" or "client-signed"
+      - For server-signed: "signedUrls" mapping relative_path -> signed_url
+      - For client-signed: "bucket" info and "files" mapping relative_path -> S3 key
     """
     # Prepare batch request
     files_data = []
@@ -51,24 +48,77 @@ def _get_batch_signed_urls(figure_url: str, files_batch: list, api_key: str) -> 
         try:
             error_data = response.json()
             error_msg = error_data.get("message", "Unknown error")
-        except:
+        except Exception:
             error_msg = f"HTTP {response.status_code}"
-        raise Exception(f"Failed to get signed URLs for batch: {error_msg}")
+        raise Exception(f"Failed to get upload info for batch: {error_msg}")
 
     response_data = response.json()
     if not response_data.get("success"):
         raise Exception(
-            f"Failed to get signed URLs for batch: {response_data.get('message', 'Unknown error')}"
+            f"Failed to get upload info for batch: {response_data.get('message', 'Unknown error')}"
         )
 
+    return response_data
+
+
+def _get_batch_signed_urls(figure_url: str, files_batch: list, api_key: str) -> dict:
+    """
+    Get signed URLs for a batch of files. Handles both server-signed and
+    client-signed modes transparently.
+
+    Returns:
+        dict: Mapping of relative_path to signed_url
+    """
+    response_data = _get_upload_info(figure_url, files_batch, api_key)
+    mode = response_data.get("mode", "server-signed")
+
+    if mode == "client-signed":
+        return _generate_client_signed_urls(response_data)
+
+    # Server-signed mode (original flow)
     signed_urls_data = response_data.get("signedUrls", [])
     if not signed_urls_data:
         raise Exception("No signed URLs returned for batch")
 
-    # Convert to mapping
     signed_urls_map = {}
     for item in signed_urls_data:
         signed_urls_map[item["relativePath"]] = item["signedUrl"]
+
+    return signed_urls_map
+
+
+def _generate_client_signed_urls(response_data: dict) -> dict:
+    """
+    Generate presigned upload URLs locally using boto3 for client-signed mode.
+    """
+    try:
+        import boto3
+    except ImportError:
+        raise ImportError(
+            "boto3 is required for uploading to buckets with client-managed credentials. "
+            "Install it with: pip install boto3"
+        )
+
+    bucket_info = response_data.get("bucket", {})
+    native_bucket_name = bucket_info["nativeBucketName"]
+    region = bucket_info.get("region", "us-east-1")
+
+    files = response_data.get("files", [])
+    if not files:
+        raise Exception("No files returned for client-signed batch")
+
+    s3_client = boto3.client("s3", region_name=region)
+
+    signed_urls_map = {}
+    for file_info in files:
+        relative_path = file_info["relativePath"]
+        key = file_info["key"]
+        signed_url = s3_client.generate_presigned_url(
+            "put_object",
+            Params={"Bucket": native_bucket_name, "Key": key},
+            ExpiresIn=3600,
+        )
+        signed_urls_map[relative_path] = signed_url
 
     return signed_urls_map
 
@@ -197,7 +247,10 @@ def _create_or_get_figure(
 
 def _finalize_figure(figure_url: str, api_key: str) -> dict:
     """
-    Finalize a figure upload
+    Finalize a figure upload.
+
+    If the bucket uses client-managed credentials, this will also upload
+    figpack.json to S3 using boto3.
 
     Returns:
         dict: Figure information from the API
@@ -219,7 +272,7 @@ def _finalize_figure(figure_url: str, api_key: str) -> dict:
         try:
             error_data = response.json()
             error_msg = error_data.get("message", "Unknown error")
-        except:
+        except Exception:
             error_msg = f"HTTP {response.status_code}"
         raise Exception(f"Failed to finalize figure {figure_url}: {error_msg}")
 
@@ -229,7 +282,51 @@ def _finalize_figure(figure_url: str, api_key: str) -> dict:
             f"Failed to finalize figure {figure_url}: {response_data.get('message', 'Unknown error')}"
         )
 
+    # If the server returned figpackJson, upload it client-side
+    figpack_json = response_data.get("figpackJson")
+    bucket_info = response_data.get("bucket")
+    if figpack_json and bucket_info:
+        _upload_figpack_json_client_side(figure_url, figpack_json, bucket_info)
+
     return response_data
+
+
+def _upload_figpack_json_client_side(
+    figure_url: str, figpack_json: dict, bucket_info: dict
+) -> None:
+    """
+    Upload figpack.json to S3 using boto3 (for client-managed credential buckets).
+    """
+    try:
+        import boto3
+    except ImportError:
+        raise ImportError(
+            "boto3 is required for uploading to buckets with client-managed credentials. "
+            "Install it with: pip install boto3"
+        )
+
+    native_bucket_name = bucket_info["nativeBucketName"]
+    region = bucket_info.get("region", "us-east-1")
+    bucket_base_url = bucket_info["bucketBaseUrl"]
+
+    # Derive the S3 key for figpack.json
+    prefix = f"{bucket_base_url}/"
+    figure_url_clean = figure_url
+    if figure_url_clean.endswith("/index.html"):
+        figure_url_clean = figure_url_clean[: -len("/index.html")]
+    if not figure_url_clean.startswith(prefix):
+        raise Exception(
+            f"Figure URL {figure_url_clean} does not start with bucket base URL {prefix}"
+        )
+    key = figure_url_clean[len(prefix) :] + "/figpack.json"
+
+    s3_client = boto3.client("s3", region_name=region)
+    s3_client.put_object(
+        Bucket=native_bucket_name,
+        Key=key,
+        Body=json.dumps(figpack_json, indent=2),
+        ContentType="application/json",
+    )
 
 
 def _upload_bundle(


### PR DESCRIPTION
Fixes #15 

## Support client-managed credentials for S3 buckets

Allow buckets to operate without server-stored AWS credentials. When credentials are omitted, the Python client resolves them locally (e.g. via boto3 SSO, environment variables, or instance profile) and uploads directly to S3.

### Changes

**API / Worker (`figpack-api-cf`)**
- **Nullable credentials**: Bucket credentials (`awsAccessKeyId`, `awsSecretAccessKey`, `s3Endpoint`) are now optional. Creating a bucket with no credentials marks it as "client-managed".
- **Dual upload mode**: The upload handler returns either `server-signed` (presigned URLs from the Worker) or `client-signed` (S3 object keys for the client to sign itself), based on whether the bucket has stored credentials.
- **`figpack.json` handling**: `updateFigureJson()` now returns the JSON content. For server-managed buckets it uploads to S3 as before; for client-managed buckets the content is returned in the finalize response so the Python client can upload it.
- **DB migration**: `0007_nullable_bucket_credentials.sql` — recreates `buckets` table with nullable credential columns.

**Python client (`figpack/core/_upload_bundle.py`)**
- Detects `client-signed` mode from the API response and generates presigned URLs locally via `boto3`.
- After finalize, uploads `figpack.json` to S3 client-side when the server returns it.
- `boto3` is imported lazily and only required for client-managed credential buckets.

**Management UI (`figpack-manage`)**
- Add/Edit bucket dialogs now offer a **credential mode** radio toggle: "Server" vs "Client".
  - **Server**: store access keys on the server; the Worker generates presigned upload URLs.
  - **Client**: no secrets stored; the uploading client resolves credentials on the fly (AWS SSO, env vars, instance profile).
- Credential fields are hidden when "Client" is selected.
- `bucketsApi.ts` types updated to reflect optional credentials.