### PR TITLE
Use boto3 for client buckets

### DIFF
--- a/figpack-api-cf/migrations/0007_nullable_bucket_credentials.sql
+++ b/figpack-api-cf/migrations/0007_nullable_bucket_credentials.sql
@@ -26,7 +26,9 @@ CREATE TABLE buckets_new (
   -- Region
   region TEXT,
   -- Owner
-  owner_email TEXT
+  owner_email TEXT,
+  -- Per-bucket override for figure expiration (seconds)
+  default_expiration_seconds INTEGER
 );
 
 INSERT INTO buckets_new
@@ -34,7 +36,8 @@ INSERT INTO buckets_new
          created_at, updated_at,
          aws_access_key_id, aws_secret_access_key, aws_session_token, s3_endpoint,
          is_public, authorized_users,
-         native_bucket_name, region, owner_email
+         native_bucket_name, region, owner_email,
+         default_expiration_seconds
   FROM buckets;
 
 DROP TABLE buckets;

--- a/figpack/core/_upload_bundle.py
+++ b/figpack/core/_upload_bundle.py
@@ -450,8 +450,7 @@ def _upload_bundle(
                 if not signed_urls_data:
                     raise Exception(f"No signed URLs returned for batch {batch_num}")
                 signed_urls_map = {
-                    item["relativePath"]: item["signedUrl"]
-                    for item in signed_urls_data
+                    item["relativePath"]: item["signedUrl"] for item in signed_urls_data
                 }
 
                 # Upload files in this batch in parallel
@@ -530,8 +529,7 @@ def _upload_bundle(
         else:
             signed_urls_data = batch_response.get("signedUrls", [])
             signed_urls_map = {
-                item["relativePath"]: item["signedUrl"]
-                for item in signed_urls_data
+                item["relativePath"]: item["signedUrl"] for item in signed_urls_data
             }
             if "manifest.json" not in signed_urls_map:
                 raise Exception("No signed URL returned for manifest.json")

--- a/figpack/core/_upload_bundle.py
+++ b/figpack/core/_upload_bundle.py
@@ -15,6 +15,9 @@ from .config import FIGPACK_API_BASE_URL, FIGPACK_BUCKET
 thisdir = pathlib.Path(__file__).parent.resolve()
 
 
+MAX_WORKERS_FOR_UPLOAD = 16
+
+
 def _get_upload_info(figure_url: str, files_batch: list, api_key: str) -> dict:
     """
     Get upload info for a batch of files from the API.
@@ -61,35 +64,28 @@ def _get_upload_info(figure_url: str, files_batch: list, api_key: str) -> dict:
     return response_data
 
 
-def _get_batch_signed_urls(figure_url: str, files_batch: list, api_key: str) -> dict:
+def _get_upload_mode(figure_url: str, files_batch: list, api_key: str) -> dict:
     """
-    Get signed URLs for a batch of files. Handles both server-signed and
-    client-signed modes transparently.
+    Get upload info and determine upload mode for a batch.
+
+    Returns the raw response_data dict from the API.
+    """
+    return _get_upload_info(figure_url, files_batch, api_key)
+
+
+def _upload_batch_client_signed(
+    response_data: dict, files_batch: list, max_workers: int = MAX_WORKERS_FOR_UPLOAD
+) -> int:
+    """
+    Upload a batch of files directly using boto3 (client-signed mode).
+
+    Args:
+        response_data: The response from _get_upload_info containing bucket info and keys
+        files_batch: List of tuples (relative_path, file_path)
+        max_workers: Number of concurrent upload threads
 
     Returns:
-        dict: Mapping of relative_path to signed_url
-    """
-    response_data = _get_upload_info(figure_url, files_batch, api_key)
-    mode = response_data.get("mode", "server-signed")
-
-    if mode == "client-signed":
-        return _generate_client_signed_urls(response_data)
-
-    # Server-signed mode (original flow)
-    signed_urls_data = response_data.get("signedUrls", [])
-    if not signed_urls_data:
-        raise Exception("No signed URLs returned for batch")
-
-    signed_urls_map = {}
-    for item in signed_urls_data:
-        signed_urls_map[item["relativePath"]] = item["signedUrl"]
-
-    return signed_urls_map
-
-
-def _generate_client_signed_urls(response_data: dict) -> dict:
-    """
-    Generate presigned upload URLs locally using boto3 for client-signed mode.
+        int: Number of files uploaded
     """
     try:
         import boto3
@@ -103,24 +99,41 @@ def _generate_client_signed_urls(response_data: dict) -> dict:
     native_bucket_name = bucket_info["nativeBucketName"]
     region = bucket_info.get("region", "us-east-1")
 
-    files = response_data.get("files", [])
-    if not files:
+    files_info = response_data.get("files", [])
+    if not files_info:
         raise Exception("No files returned for client-signed batch")
+
+    # Build key lookup from API response
+    key_map = {f["relativePath"]: f["key"] for f in files_info}
 
     s3_client = boto3.client("s3", region_name=region)
 
-    signed_urls_map = {}
-    for file_info in files:
-        relative_path = file_info["relativePath"]
-        key = file_info["key"]
-        signed_url = s3_client.generate_presigned_url(
-            "put_object",
-            Params={"Bucket": native_bucket_name, "Key": key},
-            ExpiresIn=3600,
-        )
-        signed_urls_map[relative_path] = signed_url
+    def _upload_one(rel_path: str, file_path: pathlib.Path) -> str:
+        key = key_map.get(rel_path)
+        if not key:
+            raise Exception(f"No S3 key returned for {rel_path}")
+        content_type = _determine_content_type(rel_path)
+        with open(file_path, "rb") as f:
+            s3_client.put_object(
+                Bucket=native_bucket_name,
+                Key=key,
+                Body=f,
+                ContentType=content_type,
+            )
+        return rel_path
 
-    return signed_urls_map
+    uploaded = 0
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_file = {}
+        for rel_path, file_path in files_batch:
+            future = executor.submit(_upload_one, rel_path, file_path)
+            future_to_file[future] = rel_path
+
+        for future in as_completed(future_to_file):
+            future.result()  # raises on error
+            uploaded += 1
+
+    return uploaded
 
 
 def _upload_single_file_with_signed_url(
@@ -173,9 +186,6 @@ def _upload_single_file_with_signed_url(
 
     assert last_exception is not None
     raise last_exception
-
-
-MAX_WORKERS_FOR_UPLOAD = 16
 
 
 def _create_or_get_figure(
@@ -396,6 +406,13 @@ def _upload_bundle(
         uploaded_count = 0
         count_lock = threading.Lock()
 
+        # Determine upload mode from the first batch
+        first_batch = files_to_upload[:20]
+        response_data = _get_upload_mode(
+            figure_url, first_batch, api_key if api_key else ""
+        )
+        upload_mode = response_data.get("mode", "server-signed")
+
         # Process files in batches of 20
         batch_size = 20
         for i in range(0, total_files_to_upload, batch_size):
@@ -407,47 +424,68 @@ def _upload_bundle(
                 f"Processing batch {batch_num}/{total_batches} ({len(batch)} files)..."
             )
 
-            # Get signed URLs for this batch
-            try:
-                signed_urls_map = _get_batch_signed_urls(
+            # For the first batch, reuse the response_data we already fetched
+            if i == 0:
+                batch_response = response_data
+            else:
+                batch_response = _get_upload_mode(
                     figure_url, batch, api_key if api_key else ""
                 )
-            except Exception as e:
-                print(f"Failed to get signed URLs for batch {batch_num}: {e}")
-                raise
 
-            # Upload files in this batch in parallel
-            with ThreadPoolExecutor(max_workers=MAX_WORKERS_FOR_UPLOAD) as executor:
-                # Submit upload tasks for this batch
-                future_to_file = {}
-                for rel_path, file_path in batch:
-                    if rel_path in signed_urls_map:
-                        future = executor.submit(
-                            _upload_single_file_with_signed_url,
-                            rel_path,
-                            file_path,
-                            signed_urls_map[rel_path],
+            if upload_mode == "client-signed":
+                # Direct boto3 upload
+                try:
+                    count = _upload_batch_client_signed(batch_response, batch)
+                    with count_lock:
+                        uploaded_count += count
+                        print(
+                            f"Uploaded {uploaded_count}/{total_files_to_upload} files"
                         )
-                        future_to_file[future] = rel_path
-                    else:
-                        print(f"Warning: No signed URL found for {rel_path}")
+                except Exception as e:
+                    print(f"Failed to upload batch {batch_num}: {e}")
+                    raise
+            else:
+                # Server-signed mode: use presigned URLs
+                signed_urls_data = batch_response.get("signedUrls", [])
+                if not signed_urls_data:
+                    raise Exception(f"No signed URLs returned for batch {batch_num}")
+                signed_urls_map = {
+                    item["relativePath"]: item["signedUrl"]
+                    for item in signed_urls_data
+                }
 
-                # Process completed uploads for this batch
-                for future in as_completed(future_to_file):
-                    relative_path = future_to_file[future]
-                    try:
-                        future.result()  # This will raise any exception that occurred during upload
-
-                        # Thread-safe progress update
-                        with count_lock:
-                            uploaded_count += 1
-                            print(
-                                f"Uploaded {uploaded_count}/{total_files_to_upload}: {relative_path}"
+                # Upload files in this batch in parallel
+                with ThreadPoolExecutor(max_workers=MAX_WORKERS_FOR_UPLOAD) as executor:
+                    # Submit upload tasks for this batch
+                    future_to_file = {}
+                    for rel_path, file_path in batch:
+                        if rel_path in signed_urls_map:
+                            future = executor.submit(
+                                _upload_single_file_with_signed_url,
+                                rel_path,
+                                file_path,
+                                signed_urls_map[rel_path],
                             )
+                            future_to_file[future] = rel_path
+                        else:
+                            print(f"Warning: No signed URL found for {rel_path}")
 
-                    except Exception as e:
-                        print(f"Failed to upload {relative_path}: {e}")
-                        raise  # Re-raise the exception to stop the upload process
+                    # Process completed uploads for this batch
+                    for future in as_completed(future_to_file):
+                        relative_path = future_to_file[future]
+                        try:
+                            future.result()
+
+                            # Thread-safe progress update
+                            with count_lock:
+                                uploaded_count += 1
+                                print(
+                                    f"Uploaded {uploaded_count}/{total_files_to_upload}: {relative_path}"
+                                )
+
+                        except Exception as e:
+                            print(f"Failed to upload {relative_path}: {e}")
+                            raise
 
     # Create manifest for finalization
     print("Creating manifest...")
@@ -482,20 +520,28 @@ def _upload_bundle(
     try:
         # Use batch API for manifest
         manifest_batch = [("manifest.json", temp_file_path)]
-        signed_urls_map = _get_batch_signed_urls(
+        batch_response = _get_upload_mode(
             figure_url, manifest_batch, api_key if api_key else ""
         )
+        mode = batch_response.get("mode", "server-signed")
 
-        if "manifest.json" not in signed_urls_map:
-            raise Exception("No signed URL returned for manifest.json")
+        if mode == "client-signed":
+            _upload_batch_client_signed(batch_response, manifest_batch)
+        else:
+            signed_urls_data = batch_response.get("signedUrls", [])
+            signed_urls_map = {
+                item["relativePath"]: item["signedUrl"]
+                for item in signed_urls_data
+            }
+            if "manifest.json" not in signed_urls_map:
+                raise Exception("No signed URL returned for manifest.json")
 
-        # Upload manifest using the same retry function
-        _upload_single_file_with_signed_url(
-            "manifest.json",
-            temp_file_path,
-            signed_urls_map["manifest.json"],
-            num_retries=4,
-        )
+            _upload_single_file_with_signed_url(
+                "manifest.json",
+                temp_file_path,
+                signed_urls_map["manifest.json"],
+                num_retries=4,
+            )
     finally:
         # Clean up temporary file
         temp_file_path.unlink(missing_ok=True)

--- a/tests/test_upload_bundle.py
+++ b/tests/test_upload_bundle.py
@@ -7,13 +7,13 @@ from figpack.core._upload_bundle import (
     _create_or_get_figure,
     _determine_content_type,
     _finalize_figure,
-    _get_batch_signed_urls,
+    _get_upload_mode,
     _upload_bundle,
     _upload_single_file_with_signed_url,
 )
 
 
-def test_get_batch_signed_urls(tmp_path):
+def test_get_upload_mode(tmp_path):
     # Create temporary test files
     file1 = tmp_path / "test1.txt"
     file2 = tmp_path / "test2.txt"
@@ -31,6 +31,7 @@ def test_get_batch_signed_urls(tmp_path):
     mock_response.ok = True
     mock_response.json.return_value = {
         "success": True,
+        "mode": "server-signed",
         "signedUrls": [
             {"relativePath": "path1.txt", "signedUrl": "signed-url-1"},
             {"relativePath": "path2.txt", "signedUrl": "signed-url-2"},
@@ -39,9 +40,10 @@ def test_get_batch_signed_urls(tmp_path):
 
     with mock.patch("requests.post") as mock_post:
         mock_post.return_value = mock_response
-        result = _get_batch_signed_urls(figure_url, files_batch, api_key)
+        result = _get_upload_mode(figure_url, files_batch, api_key)
 
-        assert result == {"path1.txt": "signed-url-1", "path2.txt": "signed-url-2"}
+        assert result["mode"] == "server-signed"
+        assert len(result["signedUrls"]) == 2
 
         # Verify proper API call
         mock_post.assert_called_once()
@@ -52,16 +54,16 @@ def test_get_batch_signed_urls(tmp_path):
         assert len(called_payload["files"]) == 2
 
 
-def test_get_batch_signed_urls_http_error():
+def test_get_upload_mode_http_error():
     with mock.patch("requests.post") as mock_post:
         mock_post.return_value.ok = False
         mock_post.return_value.status_code = 500
 
         with pytest.raises(Exception, match="Failed to get upload info for batch"):
-            _get_batch_signed_urls("test-url", [], "test-key")
+            _get_upload_mode("test-url", [], "test-key")
 
 
-def test_get_batch_signed_urls_api_error(tmp_path):
+def test_get_upload_mode_api_error(tmp_path):
     # Create test file
     test_file = tmp_path / "test.txt"
     test_file.write_text("test content")
@@ -76,7 +78,7 @@ def test_get_batch_signed_urls_api_error(tmp_path):
         with pytest.raises(
             Exception, match="Failed to get upload info for batch: API error message"
         ):
-            _get_batch_signed_urls("test-url", files_batch, "test-key")
+            _get_upload_mode("test-url", files_batch, "test-key")
 
 
 def test_upload_single_file_with_signed_url(tmp_path):
@@ -205,6 +207,7 @@ def test_upload_bundle(tmp_path):
     mock_batch_files_response.ok = True
     mock_batch_files_response.json.return_value = {
         "success": True,
+        "mode": "server-signed",
         "signedUrls": [
             {"relativePath": str(file1.name), "signedUrl": "signed-url-1"},
             {"relativePath": str(file2.name), "signedUrl": "signed-url-2"},
@@ -216,6 +219,7 @@ def test_upload_bundle(tmp_path):
     mock_batch_manifest_response.ok = True
     mock_batch_manifest_response.json.return_value = {
         "success": True,
+        "mode": "server-signed",
         "signedUrls": [
             {"relativePath": "manifest.json", "signedUrl": "signed-url-manifest"},
         ],


### PR DESCRIPTION
## Use boto3 directly for client-managed credential buckets

Replaces the presigned-URL intermediary with direct boto3 uploads when the bucket uses client-managed credentials.

### Problem

When using client-signed mode, the Python client was generating presigned URLs via boto3 and then uploading via `requests.put()`. This caused `SignatureDoesNotMatch` errors because the `Content-Type` header sent during upload wasn't included in the presigned URL signature.

### Solution

Since the client already has AWS credentials (via SSO, env vars, or instance profile), using presigned URLs is unnecessary. The client now calls `s3_client.put_object()` directly via boto3.

### Changes (`figpack/core/_upload_bundle.py`)

- **Removed** `_generate_client_signed_urls()` — no longer generates presigned URLs client-side.
- **Added** `_upload_batch_client_signed()` — uploads files directly using `boto3.client("s3").put_object()` with concurrent threads.
- **Added** `_get_upload_mode()` — fetches upload info from the API and returns the raw response (including `mode`).
- **Updated** `_upload_bundle()` — detects upload mode from the first batch response, then branches:
  - `server-signed`: uses presigned URLs from the Worker (unchanged).
  - `client-signed`: uploads directly via boto3.
- Manifest upload also handles both modes.
- `boto3` remains a lazy import, only required for client-managed credential buckets.